### PR TITLE
Simplify ANN backends and add grid search evaluation

### DIFF
--- a/topo/base/ann.py
+++ b/topo/base/ann.py
@@ -30,7 +30,7 @@ def kNN(X, Y=None,
         verbose=False, **kwargs):
 
     """
-    General function for computing k-nearest-neighbors graphs using NMSlib, HNSWlib, PyNNDescent, ANNOY, FAISS or scikit-learn.
+    General function for computing k-nearest-neighbors graphs using NMSlib, HNSWlib or scikit-learn.
 
     Parameters
     ----------
@@ -47,8 +47,8 @@ def kNN(X, Y=None,
         values can slightly increase computational time.
 
     backend : str (optional, default 'nmslib').
-        Which backend to use for neighborhood search. Options are 'nmslib', 'hnswlib', 
-        'pynndescent','annoy', 'faiss' and 'sklearn'.
+        Which backend to use for neighborhood search. Options are 'nmslib', 'hnswlib'
+        and 'sklearn'.
 
     metric : str (optional, default 'cosine').
         Accepted metrics. Defaults to 'cosine'. Accepted metrics include:
@@ -102,9 +102,9 @@ def kNN(X, Y=None,
         from joblib import cpu_count
         n_jobs = cpu_count()
     if Y is not None:
-        if backend == 'nmslib' or backend =='hnswlib':
-            warn("Only the 'pynndescent', 'annoy' and 'faiss' backends support Y. Falling back to 'annoy'...")
-            backend = 'annoy'
+        if backend in ['nmslib', 'hnswlib']:
+            warn("Only the 'sklearn' backend supports Y. Falling back to 'sklearn'...")
+            backend = 'sklearn'
     if backend == 'nmslib':
         if isinstance(X, np.ndarray):
             warn("nmslib does not support dense matrices. Converting to array...")
@@ -130,51 +130,6 @@ def kNN(X, Y=None,
                                        efC=efC,
                                        efS=efS,
                                        verbose=False).fit(X)
-    elif backend == 'pynndescent':
-        try:
-            from pynndescent import PyNNDescentTransformer
-        except ImportError:
-            return(print("PyNNDescent is required to use `pynndescent` as a kNN backend. Please install it with `pip install pynndescent`. "))
-        
-        if issparse(X):
-            warn("PyNNDescent does not support sparse matrices. Converting to array...")
-            X = X.toarray()
-        if metric == 'lp':
-            metric = 'minkowski'
-            metric_kwds={'p':p}
-            nbrs = PyNNDescentTransformer(metric=metric,
-                                          n_neighbors=n_neighbors,
-                                          n_jobs=n_jobs,
-                                          low_memory=low_memory,
-                                          metric_kwds=metric_kwds,
-                                          verbose=verbose, **kwargs).fit(X)
-        else:
-            nbrs = PyNNDescentTransformer(metric=metric,
-                                          n_neighbors=n_neighbors,
-                                          n_jobs=n_jobs,
-                                          low_memory=low_memory,
-                                          verbose=verbose, **kwargs).fit(X)
-    elif backend == 'annoy':
-        if issparse(X):
-            warn("Annoy does not support sparse matrices. Converting to array...")
-            X = X.toarray()
-        if Y is not None:
-            if issparse(Y):
-                Y = Y.toarray()
-        nbrs = AnnoyTransformer(metric=metric,
-                                n_neighbors=n_neighbors,
-                                n_jobs=n_jobs,
-                                n_trees=n_trees, **kwargs).fit(X)
-
-    elif backend == 'faiss':
-        try:
-            import faiss
-        except ImportError:
-            return(print("FAISS is required for using `faiss` as a kNN backend. Please install it with `pip install faiss`. "))
-
-        nbrs = FAISSTransformer(metric=metric,
-                                n_neighbors=n_neighbors,
-                                n_jobs=n_jobs, **kwargs).fit(X)
     else:
         if verbose:
             print('Falling back to sklearn nearest-neighbors!')
@@ -601,6 +556,84 @@ class NMSlibTransformer(BaseEstimator, TransformerMixin):
         return self.transform(X)
 
 
+def grid_search(X, n_neighbors=15, metric='euclidean', nmslib_params=None,
+                hnswlib_params=None, n_jobs=-1, verbose=False):
+    """Evaluate approximate kNN graph quality for NMSlib and HNSWlib.
+
+    Parameters
+    ----------
+    X : array-like or sparse matrix
+        Input data used to build the neighborhood graph.
+    n_neighbors : int, optional (default=15)
+        Number of neighbors to retrieve.
+    metric : str, optional (default='euclidean')
+        Distance metric used for neighbor search.
+    nmslib_params : dict, optional
+        Parameter grid for :class:`NMSlibTransformer`.
+    hnswlib_params : dict, optional
+        Parameter grid for :class:`HNSWlibTransformer`.
+    n_jobs : int, optional (default=-1)
+        Number of parallel jobs for the transformers.
+    verbose : bool, optional (default=False)
+        If True, print recall and timing for each parameter combination.
+
+    Returns
+    -------
+    results : dict
+        Mapping of backend names to lists of dictionaries containing
+        parameter settings, recall and execution time.
+    """
+    from sklearn.model_selection import ParameterGrid
+
+    # Compute ground-truth neighbors using exact search
+    gt = NearestNeighbors(n_neighbors=n_neighbors, metric=metric,
+                          algorithm='brute').fit(X)
+    true_ind = gt.kneighbors(X, return_distance=False)
+
+    results = {}
+
+    # Evaluate NMSlibTransformer
+    grids = ParameterGrid(nmslib_params) if nmslib_params else [{}]
+    results['nmslib'] = []
+    for params in grids:
+        model = NMSlibTransformer(n_neighbors=n_neighbors, metric=metric,
+                                  n_jobs=n_jobs, **params)
+        start = time.time()
+        model.fit(X)
+        ind, _ = model.ind_dist_grad(X, return_grad=False, return_graph=False)
+        elapsed = time.time() - start
+        ind = ind[:, 1:]
+        recall = np.mean([
+            np.intersect1d(true_ind[i], ind[i]).size / n_neighbors
+            for i in range(X.shape[0])
+        ])
+        results['nmslib'].append({'params': params, 'recall': recall, 'time': elapsed})
+
+    # Evaluate HNSWlibTransformer
+    grids = ParameterGrid(hnswlib_params) if hnswlib_params else [{}]
+    results['hnswlib'] = []
+    for params in grids:
+        model = HNSWlibTransformer(n_neighbors=n_neighbors, metric=metric,
+                                   n_jobs=n_jobs, **params)
+        start = time.time()
+        model.fit(X)
+        ind, _ = model.ind_dist_grad(X, return_grad=False, return_graph=False)
+        elapsed = time.time() - start
+        ind = ind[:, 1:]
+        recall = np.mean([
+            np.intersect1d(true_ind[i], ind[i]).size / n_neighbors
+            for i in range(X.shape[0])
+        ])
+        results['hnswlib'].append({'params': params, 'recall': recall, 'time': elapsed})
+
+    if verbose:
+        for backend, res in results.items():
+            for r in res:
+                print(f"{backend}: params={r['params']}, recall={r['recall']:.3f}, time={r['time']:.3f}s")
+
+    return results
+
+
 class HNSWlibTransformer(TransformerMixin, BaseEstimator):
     """
     Wrapper for using HNSWlib as sklearn's KNeighborsTransformer. This implements
@@ -852,318 +885,4 @@ class HNSWlibTransformer(TransformerMixin, BaseEstimator):
         return self.transform(X)
 
 
-class AnnoyTransformer(TransformerMixin, BaseEstimator):
-    """
-    Wrapper for using annoy.AnnoyIndex as sklearn's KNeighborsTransformer
-    Read more about ANNOY at https://github.com/spotify/annoy
 
-    Calling 'nn <- AnnoyTransformer()' initializes the class with default
-     neighbour search parameters.
-
-    Parameters
-    ----------
-
-    metric : str (optional, default 'euclidean').
-        Accepted ANNOY metrics. Defaults to 'euclidean'. Accepted metrics include:
-        * 'euclidean'
-        * 'angular'
-        * 'dot'
-        * 'manhattan'
-        * 'hamming'
-
-    n_jobs : int (optional, default -1).
-        Number of threads to be used in computation. Defaults to -1 (all but one).
-
-    n_trees : int (optional, default 10).
-        ANNOYS builds a forest of n_trees trees. More trees gives higher precision when querying,
-        at a higher computational cost.
-
-    """
-
-    def __init__(self, n_neighbors=5, metric="euclidean", n_trees=10, n_jobs=-1):
-        self.n_neighbors = n_neighbors
-        self.n_trees = n_trees
-        self.metric = metric
-        self.n_jobs = n_jobs
-
-    def fit(self, X):
-        try:
-            import annoy
-        except ImportError:
-            return(print("ANNOY is required to use `annoy` as a kNN backend. Please install it with `pip install annoy`. "))
-        if self.n_jobs == -1:
-            self.n_jobs = cpu_count()
-        self.n_samples_fit_ = X.shape[0]
-        self.annoy_ = annoy.AnnoyIndex(X.shape[1], metric=self.metric)
-        for i, x in enumerate(X):
-            self.annoy_.add_item(i, x.tolist())
-        self.annoy_.build(self.n_trees, n_jobs=self.n_jobs)
-        return self
-
-    def transform(self, X):
-        return self._transform(X)
-
-    def fit_transform(self, X, y=None):
-        return self.fit(X)._transform(X=None)
-
-    def _transform(self, X):
-        """As `transform`, but handles X is None for faster `fit_transform`."""
-
-        n_samples_transform = self.n_samples_fit_ if X is None else X.shape[0]
-
-        # For compatibility reasons, as each sample is considered as its own
-        # neighbor, one extra neighbor will be computed.
-        n_neighbors = self.n_neighbors + 1
-
-        indices = np.empty((n_samples_transform, n_neighbors), dtype=int)
-        distances = np.empty((n_samples_transform, n_neighbors))
-
-        if X is None:
-            for i in range(self.annoy_.get_n_items()):
-                ind, dist = self.annoy_.get_nns_by_item(
-                    i, n_neighbors, include_distances=True
-                )
-
-                indices[i], distances[i] = ind, dist
-        else:
-            for i, x in enumerate(X):
-                indices[i], distances[i] = self.annoy_.get_nns_by_vector(
-                    x.tolist(), n_neighbors, include_distances=True
-                )
-
-        indptr = np.arange(0, n_samples_transform * n_neighbors + 1, n_neighbors)
-        kneighbors_graph = csr_matrix(
-            (distances.ravel(), indices.ravel(), indptr),
-            shape=(n_samples_transform, self.n_samples_fit_),
-        )
-
-        return kneighbors_graph
-
-
-class FAISSTransformer(TransformerMixin, BaseEstimator):
-    def __init__(
-        self,
-        n_neighbors=5,
-        *,
-        metric="euclidean",
-        index_key="",
-        n_probe=128,
-        n_jobs=-1,
-        include_fwd=True,
-        include_rev=False
-    ):
-
-        self.n_neighbors = n_neighbors
-        self.metric = metric
-        self.index_key = index_key
-        self.n_probe = n_probe
-        self.n_jobs = n_jobs
-        self.include_fwd = include_fwd
-        self.include_rev = include_rev
-
-    @property
-    def _metric_info(self):
-        try:
-            import faiss
-        except ImportError:
-            return(print("FAISS is required for this function. Please install it with `pip install faiss`. "))
-
-        L2_INFO = {"metric": faiss.METRIC_L2, "sqrt": True}
-        METRIC_MAP = {
-            "cosine": {
-                "metric": faiss.METRIC_INNER_PRODUCT,
-                "normalize": True,
-                "negate": True,
-            },
-            "l1": {"metric": faiss.METRIC_L1},
-            "cityblock": {"metric": faiss.METRIC_L1},
-            "manhattan": {"metric": faiss.METRIC_L1},
-            "l2": L2_INFO,
-            "euclidean": L2_INFO,
-            "sqeuclidean": {"metric": faiss.METRIC_L2},
-            "canberra": {"metric": faiss.METRIC_Canberra},
-            "braycurtis": {"metric": faiss.METRIC_BrayCurtis},
-            "jensenshannon": {"metric": faiss.METRIC_JensenShannon},
-        }
-        return METRIC_MAP[self.metric]
-
-
-
-    def mk_faiss_index(self, feats, inner_metric, index_key="", nprobe=128):
-        try:
-            import faiss
-        except ImportError:
-            return(print("FAISS is required for this function. Please install it with `pip install faiss`. "))
-        import math
-        size, dim = feats.shape
-        if not index_key:
-            if inner_metric == faiss.METRIC_INNER_PRODUCT:
-                index = faiss.IndexFlatIP(dim)
-            else:
-                index = faiss.IndexFlatL2(dim)
-        else:
-            if index_key.find("HNSW") < 0:
-                raise NotImplementedError(
-                    "HNSW not implemented: returns distances insted of sims"
-                )
-            nlist = min(4096, 8 * round(math.sqrt(size)))
-            if index_key == "IVF":
-                quantizer = faiss.IndexFlatL2(dim)
-                index = faiss.IndexIVFFlat(quantizer, dim, nlist, inner_metric)
-            else:
-                index = faiss.index_factory(dim, index_key, inner_metric)
-            if index_key.find("Flat") < 0:
-                assert not index.is_trained
-            index.train(feats)
-            index.nprobe = min(nprobe, nlist)
-            assert index.is_trained
-        index.add(feats)
-        return index
-
-    def fit(self, X, y=None):
-        try:
-            import faiss
-        except ImportError:
-            return (print("FAISS is required for this function. Please install it with `pip install faiss`. "))
-
-        normalize = self._metric_info.get("normalize", False)
-        X = self._validate_data(X, dtype=np.float32, copy=normalize)
-        self.n_samples_fit_ = X.shape[0]
-        if self.n_jobs == -1:
-            n_jobs = cpu_count()
-        else:
-            n_jobs = self.n_jobs
-        faiss.omp_set_num_threads(n_jobs)
-        inner_metric = self._metric_info["metric"]
-        if normalize:
-            faiss.normalize_L2(X)
-        self.faiss_ = self.mk_faiss_index(X, inner_metric, self.index_key, self.n_probe)
-        return self
-
-    def transform(self, X):
-        try:
-            import faiss
-        except ImportError:
-            return (print("FAISS is required for this function. Please install it with `pip install faiss`. "))
-        normalize = self._metric_info.get("normalize", False)
-        X = self._transform_checks(X, "faiss_", dtype=np.float32, copy=normalize)
-        if normalize:
-            faiss.normalize_L2(X)
-        return self._transform(X)
-
-    def _transform(self, X):
-        try:
-            import faiss
-        except ImportError:
-            return (print("FAISS is required for this function. Please install it with `pip install faiss`. "))
-        n_samples_transform = self.n_samples_fit_ if X is None else X.shape[0]
-        n_neighbors = self.n_neighbors + 1
-        if X is None:
-            sims, nbrs = self.faiss_.search(
-                np.reshape(
-                    faiss.vector_to_array(self.faiss_.xb),
-                    (self.faiss_.ntotal, self.faiss_.d),
-                ),
-                k=n_neighbors,
-            )
-        else:
-            sims, nbrs = self.faiss_.search(X, k=n_neighbors)
-        dist_arr = np.array(sims, dtype=np.float32)
-        if self._metric_info.get("sqrt", False):
-            dist_arr = np.sqrt(dist_arr)
-        if self._metric_info.get("negate", False):
-            dist_arr = 1 - dist_arr
-        del sims
-        nbr_arr = np.array(nbrs, dtype=np.int32)
-        del nbrs
-        indptr = np.arange(0, n_samples_transform * n_neighbors + 1, n_neighbors)
-        dist_arr = np.concatenate(
-            [
-                np.zeros(
-                    (n_samples_transform, 1),
-                    dtype=dist_arr.dtype
-                ),
-                dist_arr
-            ], axis=1
-        )
-        nbr_arr = np.concatenate(
-            [
-                np.arange(n_samples_transform)[:, np.newaxis],
-                nbr_arr
-            ], axis=1
-        )
-        mat = csr_matrix(
-            (dist_arr.ravel(), nbr_arr.ravel(), indptr),
-            shape=(n_samples_transform, self.n_samples_fit_),
-        )
-        return postprocess_knn_csr(
-            mat, include_fwd=self.include_fwd, include_rev=self.include_rev
-        )
-
-    def fit_transform(self, X, y=None):
-        return self.fit(X, y=y)._transform(X=None)
-
-
-    def _more_tags(self):
-        return {
-            "_xfail_checks": {
-                "check_estimators_pickle": "Cannot pickle FAISS index",
-                "check_methods_subset_invariance": "Unable to reset FAISS internal RNG",
-            },
-            "requires_y": False,
-            "preserves_dtype": [np.float32],
-            # Could be made deterministic *if* we could reset FAISS's internal RNG
-            "non_deterministic": True,
-        }
-
-def get_sparse_row(mat, idx):
-    start_idx = mat.indptr[idx]
-    end_idx = mat.indptr[idx + 1]
-    return zip(mat.indices[start_idx:end_idx], mat.data[start_idx:end_idx])
-
-
-def or_else_csrs(csr1, csr2):
-    if csr1.shape != csr2.shape:
-        raise ValueError("csr1 and csr2 must be the same shape")
-    indptr = np.empty_like(csr1.indptr)
-    indices = []
-    data = []
-    for row_idx in range(len(indptr) - 1):
-        indptr[row_idx] = len(indices)
-        csr1_it = iter(get_sparse_row(csr1, row_idx))
-        csr2_it = iter(get_sparse_row(csr2, row_idx))
-        cur_csr1 = next(csr1_it, None)
-        cur_csr2 = next(csr2_it, None)
-        while 1:
-            if cur_csr1 is None and cur_csr2 is None:
-                break
-            elif cur_csr1 is None:
-                cur_index, cur_datum = cur_csr2
-            elif cur_csr2 is None:
-                cur_index, cur_datum = cur_csr1
-            elif cur_csr1[0] < cur_csr2[0]:
-                cur_index, cur_datum = cur_csr1
-                cur_csr1 = next(csr1_it, None)
-            elif cur_csr2[0] < cur_csr1[0]:
-                cur_index, cur_datum = cur_csr2
-                cur_csr2 = next(csr2_it, None)
-            else:
-                cur_index, cur_datum = cur_csr1
-                cur_csr1 = next(csr1_it, None)
-                cur_csr2 = next(csr2_it, None)
-            indices.append(cur_index)
-            data.append(cur_datum)
-    indptr[-1] = len(indices)
-    return csr_matrix((data, indices, indptr), shape=csr1.shape)
-
-
-def postprocess_knn_csr(knns, include_fwd=True, include_rev=False):
-    if not include_fwd and not include_rev:
-        raise ValueError("One of include_fwd or include_rev must be True")
-    elif include_rev and not include_fwd:
-        return knns.transpose(copy=False)
-    elif not include_rev and include_fwd:
-        return knns
-    else:
-        inv_knns = knns.transpose(copy=True)
-        return or_else_csrs(knns, inv_knns)


### PR DESCRIPTION
## Summary
- limit ANN support to HNSWlib and optional NMSlib, removing redundant backends
- add `grid_search` helper to benchmark ANN graphs against exact neighbors

## Testing
- `python -m py_compile topo/base/ann.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb6cd819e8832cb595fffc2b6e4b55